### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Amenities and Reservation Types

### DIFF
--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -154,18 +154,23 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
                     title="Gestionar Tipos de Reserva"
+                    aria-label={`Gestionar Tipos de Reserva para ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    title="Editar"
+                    aria-label={`Editar ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    title="Eliminar"
+                    aria-label={`Eliminar ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -212,6 +217,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
+                title="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -180,12 +180,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  title="Editar tipo de reserva"
+                  aria-label={`Editar tipo de reserva ${type.name}`}
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  title="Eliminar tipo de reserva"
+                  aria-label={`Eliminar tipo de reserva ${type.name}`}
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -265,6 +269,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
+                title="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to multiple icon-only buttons in `AmenitiesManager.tsx` and `ReservationTypesManager.tsx`.
🎯 **Why:** Icon-only buttons (like a pencil for edit or a trash can for delete) without accessible text or tooltips are confusing for screen reader users and can be ambiguous for mouse users.
♿ **Accessibility:** This ensures proper context is provided to screen readers (via `aria-label`) and helpful tooltips appear on hover for visual users (via `title`).

---
*PR created automatically by Jules for task [14017331714389979660](https://jules.google.com/task/14017331714389979660) started by @RockHarr*