### PR TITLE
🎨 Palette: Add context to admin icon-only buttons

### DIFF
--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -112,6 +112,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
             <button
               onClick={() => onNavigate('admin-dashboard')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Volver al panel de control"
+              title="Volver al panel de control"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -160,12 +162,16 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    aria-label="Editar espacio"
+                    title="Editar espacio"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    aria-label="Eliminar espacio"
+                    title="Eliminar espacio"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -212,6 +218,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
+                title="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -149,6 +149,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
             <button
               onClick={() => onNavigate('admin-amenities')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Volver a espacios comunes"
+              title="Volver a espacios comunes"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -180,12 +182,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  aria-label="Editar tipo de reserva"
+                  title="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  aria-label="Eliminar tipo de reserva"
+                  title="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -265,6 +271,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
+                title="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons (back arrows, edit/pencil, delete/trash, and close/xmark) across `AmenitiesManager.tsx` and `ReservationTypesManager.tsx`.
🎯 Why: Icon-only buttons lacked accessible names, making them difficult for screen reader users to understand and non-intuitive for mouse users without hover context. This micro-UX improvement provides native tooltips and clear accessibility labels.
♿ Accessibility: Improved screen reader support by giving explicit context to destructive and navigational actions.

---
*PR created automatically by Jules for task [4705893933165092377](https://jules.google.com/task/4705893933165092377) started by @RockHarr*