### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/components/AdminCreateReservationModal.tsx
+++ b/components/AdminCreateReservationModal.tsx
@@ -78,7 +78,7 @@ export const AdminCreateReservationModal: React.FC<AdminCreateReservationModalPr
                     <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                         Nueva Reserva (Admin)
                     </h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -112,6 +112,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
             <button
               onClick={() => onNavigate('admin-dashboard')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Volver al panel"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -154,18 +155,21 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
                     title="Gestionar Tipos de Reserva"
+                    aria-label={`Gestionar tipos de reserva para ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    aria-label={`Editar espacio ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    aria-label={`Eliminar espacio ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -212,6 +216,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -149,6 +149,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
             <button
               onClick={() => onNavigate('admin-amenities')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Volver a espacios comunes"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -180,12 +181,14 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  aria-label={`Editar tipo de reserva ${type.name}`}
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  aria-label={`Eliminar tipo de reserva ${type.name}`}
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -265,6 +268,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/TicketsScreen.tsx
+++ b/components/TicketsScreen.tsx
@@ -288,6 +288,7 @@ export const CreateTicketScreen: React.FC<CreateTicketScreenProps> = ({ onAddTic
                             setError(null);
                           }}
                           className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 shadow-md hover:bg-red-600"
+                          aria-label="Eliminar foto"
                         >
                           <Icons name="xmark" className="w-4 h-4" />
                         </button>

--- a/tests/e2e/reservations_menu_smoke.spec.ts
+++ b/tests/e2e/reservations_menu_smoke.spec.ts
@@ -15,7 +15,7 @@ test('reservations_menu_smoke', async ({ page }) => {
     // 2. Login as Admin (Mock)
     // Assuming default dev login flow or using a known credential if E2E setup allows
     // For smoke test on existing session or quick login:
-    await page.goto('http://localhost:5173');
+    await page.goto('/');
 
     // Fill login if redirected to login
     if (await page.getByText('Iniciar Sesión').isVisible()) {


### PR DESCRIPTION
* 💡 What: Added missing `aria-label` attributes to icon-only buttons across multiple components (`AdminCreateReservationModal`, `ReservationRequestModal`, `AmenitiesManager`, `ReservationTypesManager`, and `TicketsScreen`).
* 🎯 Why: Improves screen reader compatibility and general accessibility by providing context to interactive elements that lack visual text.
* 📸 Before/After: Visual UI remains unchanged.
* ♿ Accessibility: Screen reader users will now hear descriptive labels (e.g., "Cerrar modal", "Eliminar espacio Piscina") instead of silence or generic "button" announcements.

---
*PR created automatically by Jules for task [16056235367079396621](https://jules.google.com/task/16056235367079396621) started by @RockHarr*