### PR TITLE
🎨 Palette: [Accessibility] Add tooltips and ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-05-24 - Accessibility for Action Buttons in Lists
+**Learning:** Found multiple instances of icon-only action buttons (edit, delete) inside mapped lists without accessibility attributes. Screen reader users would only hear "button", "button" with no context of which item they were modifying.
+**Action:** Always add `aria-label` and `title` to icon-only buttons. Crucially, when these buttons are inside a list, use string interpolation to include the item's name in the label (e.g., ``aria-label={`Eliminar ${item.name}`}``) to provide specific context.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -153,19 +153,24 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
-                    title="Gestionar Tipos de Reserva"
+                    title={`Gestionar Tipos de Reserva de ${amenity.name}`}
+                    aria-label={`Gestionar Tipos de Reserva de ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    title={`Editar ${amenity.name}`}
+                    aria-label={`Editar ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    title={`Eliminar ${amenity.name}`}
+                    aria-label={`Eliminar ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -180,12 +180,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  title={`Editar ${type.name}`}
+                  aria-label={`Editar ${type.name}`}
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  title={`Eliminar ${type.name}`}
+                  aria-label={`Eliminar ${type.name}`}
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>

--- a/components/TicketsScreen.tsx
+++ b/components/TicketsScreen.tsx
@@ -288,6 +288,8 @@ export const CreateTicketScreen: React.FC<CreateTicketScreenProps> = ({ onAddTic
                             setError(null);
                           }}
                           className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 shadow-md hover:bg-red-600"
+                          title="Eliminar foto"
+                          aria-label="Eliminar foto"
                         >
                           <Icons name="xmark" className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` and `title` attributes to icon-only action buttons (edit, delete) inside mapped lists in `AmenitiesManager.tsx` and `ReservationTypesManager.tsx`, as well as the photo removal button in `TicketsScreen.tsx`.

🎯 Why: Icon-only buttons without accessible names cause screen readers to simply announce "button", providing zero context to visually impaired users about what action the button performs or which list item it modifies.

♿ Accessibility: Contextual string interpolation (e.g., ``aria-label={`Editar ${amenity.name}`}``) ensures screen reader users explicitly know which item they are acting upon within a list.

---
*PR created automatically by Jules for task [17292189828091355073](https://jules.google.com/task/17292189828091355073) started by @RockHarr*