### PR TITLE
🎨 Palette: [a11y improvement] Dynamic aria-labels for list action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2026-04-14 - Dynamic ARIA labels for mapping components
+**Learning:** Added string interpolation to map iterations to add descriptive aria labels to repeated icon buttons. This provides better screen-reader accessibility for items like 'Edit <item name>' vs. just 'Edit' repeated multiple times.
+**Action:** When adding `aria-label` attributes to icon-only buttons within iterated lists or mapped elements, utilize dynamic string interpolation to provide context-specific descriptions.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -154,18 +154,21 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
                     title="Gestionar Tipos de Reserva"
+                    aria-label={`Gestionar tipos de reserva para ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    aria-label={`Editar ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    aria-label={`Eliminar ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -180,12 +180,14 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  aria-label={`Editar ${type.name}`}
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  aria-label={`Eliminar ${type.name}`}
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>

--- a/tests/e2e/setup.spec.ts
+++ b/tests/e2e/setup.spec.ts
@@ -43,7 +43,7 @@ test.describe('System Setup', () => {
         const card = page.locator('.group', { has: page.getByRole('heading', { name: 'Quincho', exact: true }) }).first();
         // Force click the hidden button or hover
         await card.hover();
-        const manageTypesBtn = card.getByTitle('Gestionar Tipos de Reserva');
+        const manageTypesBtn = card.getByRole('button', { name: 'Gestionar tipos de reserva para Quincho' });
         await manageTypesBtn.click();
 
         await expect(page.getByRole('heading', { name: 'Tipos de Reserva' })).toBeVisible();


### PR DESCRIPTION
💡 What: Added `aria-label` attributes with dynamic string interpolation to icon-only buttons inside lists.
🎯 Why: Without string interpolation, every edit/delete button would be announced to a screen reader simply as "Edit" or "Delete" without context, making it confusing to know which row was about to be edited/deleted. This gives them names like "Editar Quincho" or "Eliminar Sala Multiuso".
♿ Accessibility: Improved screen-reader context for repeated action buttons within map iterations in AmenitiesManager.tsx and ReservationTypesManager.tsx.

---
*PR created automatically by Jules for task [1099775626020374233](https://jules.google.com/task/1099775626020374233) started by @RockHarr*