### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in AmenitiesManager

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2024-05-04 - Adding ARIA labels and focus states to icon-only buttons
+**Learning:** Icon-only interactive elements lacking `aria-label`s fail basic accessibility checks, making them completely opaque to screen readers. Focus states inside absolute positioned/opacity hidden buttons (`group-hover:opacity-100`) also require `focus-within:opacity-100` to be reachable via keyboard navigation (Tab key).
+**Action:** Always ensure icon-only buttons include `aria-label`, `type="button"`, and keyboard focus visibility (`focus-visible:ring-2`). If hidden behind a hover state, add `focus-within:opacity-100` to the parent to make keyboard navigation work. Test outputs and artifact folders MUST be removed locally before creating commits to prevent repo bloat.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -110,6 +110,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
         <div>
           <div className="flex items-center gap-2 mb-1">
             <button
+              type="button"
+              aria-label="Volver al panel de administración"
               onClick={() => onNavigate('admin-dashboard')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             >
@@ -149,23 +151,29 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <button
+                    type="button"
+                    aria-label={`Gestionar tipos de reserva de ${amenity.name}`}
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2 focus-visible:ring-green-500 focus:outline-none"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
+                    type="button"
+                    aria-label={`Editar espacio ${amenity.name}`}
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
+                    type="button"
+                    aria-label={`Eliminar espacio ${amenity.name}`}
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -210,8 +218,10 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                 {editingAmenity ? 'Editar Espacio' : 'Nuevo Espacio'}
               </h2>
               <button
+                type="button"
+                aria-label="Cerrar modal"
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 focus-visible:ring-gray-500 focus:outline-none rounded"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label`, `type="button"`, and `focus-visible:ring-*` classes to all icon-only interactive elements in `components/AmenitiesManager.tsx`. Additionally, `focus-within:opacity-100` was added to the actions container so they appear when navigating via keyboard (Tab key).
🎯 **Why**: Icon-only buttons without an `aria-label` are inaccessible to screen readers, leaving visually impaired users with no context on what the button does. Without `type="button"`, these elements can mistakenly trigger forms, and lacking focus rings makes keyboard navigation extremely difficult.
📸 **Before/After**: Visually identical on initial load, but now action elements display a focus ring (e.g., `ring-blue-500`) when focused with the keyboard. Hover states now correctly respond to keyboard focus as well.
♿ **Accessibility**: Significant improvement to screen reader support and keyboard-only navigation. Added `.Jules/palette.md` entry reflecting the learnings from these changes.

---
*PR created automatically by Jules for task [7972363260330518480](https://jules.google.com/task/7972363260330518480) started by @RockHarr*