### PR TITLE
🎨 Palette: Add accessibility attributes to modal close buttons and fix keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-05-25 - Accessibility of Icon-only Buttons
+**Learning:** Icon-only close buttons in modals across the application lacked `aria-label` attributes, making them inaccessible to screen readers. In `AmenitiesManager.tsx`, hover-only action buttons also lacked keyboard accessibility and `aria-label`s.
+**Action:** Always add descriptive `aria-label`s to icon-only buttons (e.g., `aria-label="Cerrar modal"`). For elements hidden behind hover states, ensure keyboard accessibility by applying `focus-within:opacity-100` to the container and providing `focus-visible:ring-*` styles to the interactive children.

--- a/components/AdminCreateReservationModal.tsx
+++ b/components/AdminCreateReservationModal.tsx
@@ -78,7 +78,7 @@ export const AdminCreateReservationModal: React.FC<AdminCreateReservationModalPr
                     <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                         Nueva Reserva (Admin)
                     </h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,26 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
                     title="Gestionar Tipos de Reserva"
+                    aria-label="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label="Editar espacio"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                    aria-label="Eliminar espacio"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -212,6 +215,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationPaymentModal.tsx
+++ b/components/ReservationPaymentModal.tsx
@@ -40,8 +40,9 @@ export const ReservationPaymentModal: React.FC<ReservationPaymentModalProps> = (
                 <button
                     onClick={onClose}
                     className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                    aria-label="Cerrar modal"
                 >
-                    <Icons name="x-mark" className="w-6 h-6" />
+                    <Icons name="xmark" className="w-6 h-6" />
                 </button>
 
                 <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-6 flex items-center gap-2">

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label="Cerrar modal"` to icon-only close buttons across various modals (`AdminCreateReservationModal`, `AmenitiesManager`, `ReservationPaymentModal`, `ReservationRequestModal`). Also improved keyboard navigation for the action buttons in `AmenitiesManager` by adding `focus-within:opacity-100` and specific `aria-label`s. Fixed a broken icon name in `ReservationPaymentModal` (`x-mark` to `xmark`).
🎯 **Why**: Modals rely on icon-only buttons for closing, making them invisible to screen readers without descriptive text. Additionally, hover-only action buttons in list managers prevent keyboard-only users from accessing editing and deleting functionalities.
📸 **Before/After**: Visually identical (except focus states), but screen readers will now announce "Cerrar modal", "Gestionar Tipos de Reserva", "Editar espacio", and "Eliminar espacio". Keyboard navigation via 'Tab' now reveals hidden actions with proper focus rings.
♿ **Accessibility**: Enhanced screen reader support for multiple common modals and fixed a strict keyboard navigation block in the Amenities manager.

---
*PR created automatically by Jules for task [11629223068825696335](https://jules.google.com/task/11629223068825696335) started by @RockHarr*