### PR TITLE
🎨 Palette: Keyboard Accessibility for Hover-State Action Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-06-11 - Hover State Keyboard Accessibility
+**Learning:** Action buttons hidden behind a hover state (e.g., `opacity-0 group-hover:opacity-100`) are invisible to keyboard-only users who navigate via the Tab key, making critical actions inaccessible.
+**Action:** Always include `group-focus-within:opacity-100` (or `focus-within:opacity-100`) alongside `group-hover:opacity-100` to ensure keyboard accessibility. Ensure all interactive icon-only buttons have explicit `aria-label`, `type="button"`, and `focus-visible:ring-2`.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -110,8 +110,10 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
         <div>
           <div className="flex items-center gap-2 mb-1">
             <button
+              type="button"
+              aria-label="Volver a inicio"
               onClick={() => onNavigate('admin-dashboard')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus-visible:ring-2 rounded-md"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -149,23 +151,29 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
+                    type="button"
+                    aria-label={`Gestionar tipos de reserva de ${amenity.name}`}
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
+                    type="button"
+                    aria-label={`Editar ${amenity.name}`}
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
+                    type="button"
+                    aria-label={`Eliminar ${amenity.name}`}
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -210,8 +218,10 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                 {editingAmenity ? 'Editar Espacio' : 'Nuevo Espacio'}
               </h2>
               <button
+                type="button"
+                aria-label="Cerrar modal"
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 rounded-md"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -147,8 +147,10 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
         <div>
           <div className="flex items-center gap-2 mb-1">
             <button
+              type="button"
+              aria-label="Volver a espacios comunes"
               onClick={() => onNavigate('admin-amenities')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus-visible:ring-2 rounded-md"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -176,16 +178,20 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
+                  type="button"
+                  aria-label={`Editar ${type.name}`}
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:ring-2"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
+                  type="button"
+                  aria-label={`Eliminar ${type.name}`}
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:ring-2"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -263,8 +269,10 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 {editingType ? 'Editar Tipo de Reserva' : 'Nuevo Tipo de Reserva'}
               </h2>
               <button
+                type="button"
+                aria-label="Cerrar modal"
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 rounded-md"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
🎨 **Palette: Hover State Keyboard Accessibility & ARIA Labels**

💡 **What:** 
- Added `group-focus-within:opacity-100` to the action button containers in `AmenitiesManager` and `ReservationTypesManager`.
- Added dynamic, descriptive `aria-label` attributes (e.g., `aria-label="Editar Quincho Norte"`) to the icon-only "Gestionar", "Editar", and "Eliminar" buttons.
- Added `type="button"` and `focus-visible:ring-2` to all interactive icon-only buttons (including the "Volver" back buttons and "Cerrar modal" close buttons).
- Updated the `.Jules/palette.md` journal with a critical learning regarding hover states and keyboard navigation.

🎯 **Why:** 
Previously, the action buttons for managing amenities and reservation types were hidden using `opacity-0 group-hover:opacity-100`. This is a classic accessibility anti-pattern because users navigating with a keyboard (using the `Tab` key) could focus on the buttons, but they remained invisible, making critical actions impossible to perform confidently. Furthermore, these buttons contained only SVG icons without text or ARIA labels, making them incomprehensible to screen reader users.

♿ **Accessibility:** 
- **Keyboard Navigation:** Action buttons now become fully visible when focused via keyboard.
- **Screen Readers:** All icon-only buttons now have context-aware, descriptive labels.
- **Focus Indicators:** Added visible rings when focused to improve orientation.

---
*PR created automatically by Jules for task [4951718887533884145](https://jules.google.com/task/4951718887533884145) started by @RockHarr*