### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to modal close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-06-13 - Modal Close Button Accessibility
+**Learning:** Many custom modal implementations in the application (like `ReservationRequestModal` or `AmenitiesManager`) feature an 'X' icon for closing, but rely entirely on visual cues. They lack the necessary `aria-label` attributes on the surrounding `<button>`, making them inaccessible and indistinguishable to screen readers.
+**Action:** Always verify that icon-only buttons, especially those managing critical UI overlays like modals or alerts, have an explicit, translated `aria-label` attribute (e.g., `aria-label="Cerrar modal"`).

--- a/components/AdminCreateReservationModal.tsx
+++ b/components/AdminCreateReservationModal.tsx
@@ -78,7 +78,7 @@ export const AdminCreateReservationModal: React.FC<AdminCreateReservationModalPr
                     <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                         Nueva Reserva (Admin)
                     </h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -212,6 +212,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -265,6 +265,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label="Cerrar modal"` to icon-only close buttons across four key modal components.
🎯 **Why**: Modal close buttons were using a visual `xmark` icon without any text equivalent, making them indistinguishable and inaccessible to screen reader users. 
📸 **Before/After**: Visually identical. Under the hood, `<button>` tags now properly describe their function.
♿ **Accessibility**: Provides an explicit, localized text description for screen readers navigating modal overlays.

---
*PR created automatically by Jules for task [8818538095009581619](https://jules.google.com/task/8818538095009581619) started by @RockHarr*