### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Security Headers to vercel.json

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** The application was directly rendering `expense.evidenciaUrl` in an `href` attribute without sanitization in the `AdminDashboard`. This allowed for potential Cross-Site Scripting (XSS) if an attacker could input a malicious payload (e.g., `javascript:alert(1)`) into the URL.
 **Learning:** Any user-supplied data used in attributes like `href`, `src`, or `action` must be treated as untrusted and sanitized before rendering, even if it comes from a supposedly secure backend or database, to follow the principle of defense-in-depth.
 **Prevention:** Use a dedicated sanitization function like `getSafeUrl` to validate the URL's protocol against an allowlist (e.g., `http:`, `https:`, `mailto:`, `tel:`) before rendering it in the UI.
+## 2025-03-05 - Missing Security Headers in Vercel Configuration
+**Vulnerability:** The Vercel deployment configuration lacked security headers such as Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, and Referrer-Policy, exposing the application to potential cross-site scripting (XSS), clickjacking, and mime-sniffing attacks.
+**Learning:** The application relies on external CDNs (Tailwind, React from aistudiocdn.com, Google Fonts) and local dummy backend URLs for CI tests, requiring a carefully constructed CSP to secure the app without breaking the UI or tests.
+**Prevention:** Always implement explicit security headers in deployment configurations (`vercel.json`) and carefully whitelist required domains for external resources and CI environments.

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,33 @@
             "destination": "/index.html"
         }
     ],
+    "headers": [
+        {
+            "source": "/(.*)",
+            "headers": [
+                {
+                    "key": "Content-Security-Policy",
+                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://aistudiocdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co http://127.0.0.1:54321; img-src 'self' data: https://images.unsplash.com blob:"
+                },
+                {
+                    "key": "X-Content-Type-Options",
+                    "value": "nosniff"
+                },
+                {
+                    "key": "X-Frame-Options",
+                    "value": "DENY"
+                },
+                {
+                    "key": "X-XSS-Protection",
+                    "value": "1; mode=block"
+                },
+                {
+                    "key": "Referrer-Policy",
+                    "value": "strict-origin-when-cross-origin"
+                }
+            ]
+        }
+    ],
     "buildCommand": "npm run build",
     "outputDirectory": "dist",
     "cleanUrls": true


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Vercel deployment configuration lacked security headers such as Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, and Referrer-Policy, exposing the application to potential cross-site scripting (XSS), clickjacking, and mime-sniffing attacks.
🎯 Impact: Attackers could potentially exploit missing CSP to load malicious scripts or embed the application in an iframe to execute clickjacking attacks.
🔧 Fix: Added explicit security headers in deployment configurations (`vercel.json`), carefully whitelisting required domains for external resources (Tailwind, Google Fonts) and CI environments.
✅ Verification: Ensure the application still builds and functions correctly in production and that headers are returned in the response by running `curl -I https://gestion-condominio-facil.vercel.app`.

---
*PR created automatically by Jules for task [14439477868389317566](https://jules.google.com/task/14439477868389317566) started by @RockHarr*