### PR TITLE
🎨 Palette: Add aria-labels to icon-only close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2025-06-17 - Icon Button Accessibility
+**Learning:** Icon-only buttons used for closing modals throughout the application lacked `aria-label` attributes, making them inaccessible to screen readers.
+**Action:** Always add descriptive `aria-label` attributes to icon-only `<button>` elements, particularly those using `<Icons name="xmark" />` for closing modals or deleting content.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+test-results/
+playwright-report/

--- a/components/AdminCreateReservationModal.tsx
+++ b/components/AdminCreateReservationModal.tsx
@@ -78,7 +78,7 @@ export const AdminCreateReservationModal: React.FC<AdminCreateReservationModalPr
                     <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                         Nueva Reserva (Admin)
                     </h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -212,6 +212,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -265,6 +265,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/TicketsScreen.tsx
+++ b/components/TicketsScreen.tsx
@@ -288,6 +288,7 @@ export const CreateTicketScreen: React.FC<CreateTicketScreenProps> = ({ onAddTic
                             setError(null);
                           }}
                           className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 shadow-md hover:bg-red-600"
+                          aria-label="Eliminar foto"
                         >
                           <Icons name="xmark" className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
🎨 Palette: Accessibility improvements for icon-only buttons

💡 **What**: Added descriptive `aria-label` attributes to multiple icon-only buttons across the application that utilize the `xmark` icon for closing modals or deleting content.

🎯 **Why**: Previously, these buttons had no text content or ARIA labels, making them invisible or confusing for users relying on screen readers. Adding these labels ensures keyboard and screen reader users understand the purpose of these actions.

♿ **Accessibility**:
- Added `aria-label="Cerrar modal"` to close buttons in `AdminCreateReservationModal`, `AmenitiesManager`, `ReservationRequestModal`, and `ReservationTypesManager`.
- Added `aria-label="Eliminar foto"` to the photo removal button in `TicketsScreen`.
- Recorded the pattern in `.Jules/palette.md` to ensure future modals include these labels by default.

---
*PR created automatically by Jules for task [2511893344522129772](https://jules.google.com/task/2511893344522129772) started by @RockHarr*