### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-06-18 - Missing ARIA Labels on Icon-only Buttons
+**Learning:** Icon-only buttons used for secondary actions (like edit, delete, or close modals) consistently lacked `aria-label` attributes across multiple manager components (`AmenitiesManager`, `ReservationTypesManager`, etc.). Screen reader users would hear these merely as "button" with no context. For buttons within iterative lists, using dynamic string interpolation (e.g., ``aria-label={`Eliminar espacio ${amenity.name}`}``) provides essential context.
+**Action:** Always ensure that `<Icons>` components used inside buttons are accompanied by explicit, descriptive `aria-label` attributes, especially when no visible text is present. Use dynamic strings inside loops to distinguish between similar actions.

--- a/components/AdminCreateReservationModal.tsx
+++ b/components/AdminCreateReservationModal.tsx
@@ -78,7 +78,7 @@ export const AdminCreateReservationModal: React.FC<AdminCreateReservationModalPr
                     <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                         Nueva Reserva (Admin)
                     </h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -112,6 +112,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
             <button
               onClick={() => onNavigate('admin-dashboard')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Volver"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -154,18 +155,21 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
                     title="Gestionar Tipos de Reserva"
+                    aria-label={`Gestionar tipos de reserva ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    aria-label={`Editar espacio ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    aria-label={`Eliminar espacio ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -212,6 +216,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationPaymentModal.tsx
+++ b/components/ReservationPaymentModal.tsx
@@ -40,6 +40,7 @@ export const ReservationPaymentModal: React.FC<ReservationPaymentModalProps> = (
                 <button
                     onClick={onClose}
                     className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                    aria-label="Cerrar modal"
                 >
                     <Icons name="x-mark" className="w-6 h-6" />
                 </button>

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -149,6 +149,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
             <button
               onClick={() => onNavigate('admin-amenities')}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              aria-label="Volver"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -180,12 +181,14 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  aria-label={`Editar tipo de reserva ${type.name}`}
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  aria-label={`Eliminar tipo de reserva ${type.name}`}
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -265,6 +268,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <button
                 onClick={() => setModalOpen(false)}
                 className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/TicketsScreen.tsx
+++ b/components/TicketsScreen.tsx
@@ -288,6 +288,7 @@ export const CreateTicketScreen: React.FC<CreateTicketScreenProps> = ({ onAddTic
                             setError(null);
                           }}
                           className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 shadow-md hover:bg-red-600"
+                          aria-label="Quitar foto"
                         >
                           <Icons name="xmark" className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
* Added `aria-label` attributes to icon-only buttons across multiple components (`AmenitiesManager`, `ReservationTypesManager`, modals, etc.) to improve screen reader accessibility.
* Utilized dynamic string interpolation for buttons within iterative lists (e.g., ``aria-label={\`Eliminar espacio \${amenity.name}\`}``) to provide necessary context.
* Kept labels in Spanish to match the application's localization.
* Updated `.Jules/palette.md` with learnings regarding icon-only button accessibility.

---
*PR created automatically by Jules for task [10966057930325257501](https://jules.google.com/task/10966057930325257501) started by @RockHarr*