### PR TITLE
🎨 Palette: Enhance Accessibility of Hover-Revealed Action Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,7 +13,3 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
-
-## 2025-06-19 - Keyboard Accessibility for Hover-Revealed Actions
-**Learning:** Elements hidden with `opacity-0 group-hover:opacity-100` are invisible to keyboard-only users navigating via Tab, causing confusion and inaccessible actions.
-**Action:** Always add `group-focus-within:opacity-100` or `focus-within:opacity-100` to the container and `focus-visible:ring-2 focus:outline-none` to interactive elements to ensure they become visible and properly outlined when receiving keyboard focus.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-06-19 - Keyboard Accessibility for Hover-Revealed Actions
+**Learning:** Elements hidden with `opacity-0 group-hover:opacity-100` are invisible to keyboard-only users navigating via Tab, causing confusion and inaccessible actions.
+**Action:** Always add `group-focus-within:opacity-100` or `focus-within:opacity-100` to the container and `focus-visible:ring-2 focus:outline-none` to interactive elements to ensure they become visible and properly outlined when receiving keyboard focus.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,26 +149,23 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
                     title="Gestionar Tipos de Reserva"
-                    aria-label={`Gestionar tipos de reserva para ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    aria-label={`Editar ${amenity.name}`}
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    aria-label={`Eliminar ${amenity.name}`}
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,26 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     title="Gestionar Tipos de Reserva"
+                    aria-label={`Gestionar tipos de reserva para ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label={`Editar ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label={`Eliminar ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,11 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button
-                        onClick={onClose}
-                        className="text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
-                        aria-label="Cerrar modal"
-                    >
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,11 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
+                        aria-label="Cerrar modal"
+                    >
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,18 +176,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                  aria-label={`Editar tipo ${type.name}`}
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                  aria-label={`Eliminar tipo ${type.name}`}
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -266,8 +264,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
-                aria-label="Cerrar modal"
+                className="text-gray-400 hover:text-gray-500"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,18 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label={`Editar tipo ${type.name}`}
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label={`Eliminar tipo ${type.name}`}
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -264,7 +266,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
This PR improves the keyboard and screen reader accessibility of icon-only action buttons.

Previously, buttons that were only revealed on hover (using `opacity-0 group-hover:opacity-100`) were invisible to users navigating with the `Tab` key, making them completely inaccessible. This has been fixed by introducing `group-focus-within:opacity-100`.

Additionally, icon-only buttons lacked `aria-label`s, which has been corrected by adding descriptive string interpolated labels. Focus outlines (`focus-visible:ring-2`) have also been applied.

---
*PR created automatically by Jules for task [3806760318123300178](https://jules.google.com/task/3806760318123300178) started by @RockHarr*