### PR TITLE
🎨 Palette: Improve keyboard accessibility and screen reader support for amenity actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2025-06-22 - [a11y] Keyboard focus for hover-revealed action buttons
+**Learning:** When using `group-hover:opacity-100` to reveal action buttons on hover over a card/image (e.g. in AmenitiesManager), these buttons become inaccessible to keyboard-only users who tab through the interface. Furthermore, icon-only buttons in mapped lists must have descriptive dynamic `aria-label`s to give context for screen readers.
+**Action:** Always add `focus-within:opacity-100` to the container revealing elements on hover. Ensure all interactive elements have visible focus states (e.g., `focus-visible:ring-2`) and dynamic string interpolation for `aria-label`s when mapping over arrays.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright artifacts
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,26 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 focus-visible:ring-2 focus-visible:ring-green-500 focus:outline-none text-green-600"
                     title="Gestionar Tipos de Reserva"
+                    aria-label={`Gestionar tipos de reserva para ${amenity.name}`}
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none text-blue-600"
+                    aria-label={`Editar ${amenity.name}`}
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none text-red-600"
+                    aria-label={`Eliminar ${amenity.name}`}
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
🎨 Palette: Improve keyboard accessibility and screen reader support for amenity actions

### 💡 What
- Modified `AmenitiesManager.tsx` to add `focus-within:opacity-100` to the container that reveals action buttons on hover (`group-hover:opacity-100`).
- Added dynamic, translated `aria-label`s to the three action buttons (e.g., `Gestionar tipos de reserva para Quincho`).
- Ensured proper focus states via `focus-visible:ring-2` for keyboard-only users.

### 🎯 Why
- Elements hidden via `opacity-0` but present in the DOM are focusable, but remain invisible to keyboard users when they tab onto them if only `group-hover` is used.
- Icon-only buttons lack accessible text for screen readers; adding dynamic ARIA labels resolves this.

### ♿ Accessibility
- Fixed WCAG 2.1 Success Criterion 2.4.7 Focus Visible by explicitly showing elements on focus.
- Improved context for screen readers.

---
*PR created automatically by Jules for task [13590004219340693313](https://jules.google.com/task/13590004219340693313) started by @RockHarr*