### PR TITLE
🛡️ Sentinel: Fix Information Disclosure in Authentication Logs

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The application was directly rendering `expense.evidenciaUrl` in an `href` attribute without sanitization in the `AdminDashboard`. This allowed for potential Cross-Site Scripting (XSS) if an attacker could input a malicious payload (e.g., `javascript:alert(1)`) into the URL.
 **Learning:** Any user-supplied data used in attributes like `href`, `src`, or `action` must be treated as untrusted and sanitized before rendering, even if it comes from a supposedly secure backend or database, to follow the principle of defense-in-depth.
 **Prevention:** Use a dedicated sanitization function like `getSafeUrl` to validate the URL's protocol against an allowlist (e.g., `http:`, `https:`, `mailto:`, `tel:`) before rendering it in the UI.
+
+## 2025-10-24 - [Information Disclosure in Authentication Logs]
+**Vulnerability:** The application was logging password update results directly to the console (`console.log('AuthService: updatePassword result', result.data, result.error);`). This is an Information Disclosure vulnerability because any extension, background script, or user inspecting the console could potentially intercept error objects containing sensitive authentication context or inadvertently logged password traces if `result.data` or `error` contained them. It also violates the fail-secure principle by leaking backend error messages and stack traces.
+**Learning:** Never log sensitive operations (like authentication, password changes) or raw error objects from these operations to the client-side console.
+**Prevention:** Remove excessive logging in production, especially for authentication flows. Log generic error states to the UI and ensure server responses do not contain sensitive data or stack traces.

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -82,10 +82,8 @@ const PasswordChangeSection: React.FC = () => {
       return;
     }
 
-    console.log('ProfileScreen: Attempting to update password...');
     try {
       const { error } = await authService.updatePassword(password);
-      console.log('ProfileScreen: Update password result', error);
 
       if (error) {
         const errMsg = error.message || JSON.stringify(error);
@@ -103,7 +101,6 @@ const PasswordChangeSection: React.FC = () => {
         setTimeout(() => setIsOpen(false), 2000);
       }
     } catch (err: unknown) {
-      console.error('ProfileScreen: Exception updating password', err);
       setMessage({ text: 'Error inesperado: ' + getErrorMessage(err), type: 'error' });
     } finally {
       setLoading(false);

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -45,7 +45,6 @@ export const authService = {
   },
 
   async updatePassword(password: string) {
-    console.log('AuthService: updatePassword called');
     try {
       const result = await Promise.race([
         supabase.auth.updateUser({ password: password }),
@@ -56,10 +55,8 @@ export const authService = {
           ),
         ),
       ]);
-      console.log('AuthService: updatePassword result', result.data, result.error);
       return result;
     } catch (err) {
-      console.error('AuthService: updatePassword timeout or error', err);
       const error = err instanceof Error ? err : new Error('Unknown error');
       return { data: { user: null }, error };
     }


### PR DESCRIPTION
This change addresses a medium-severity Information Disclosure vulnerability by removing unnecessary `console.log` and `console.error` logs that were emitting authentication results, specifically related to password updates. This ensures that potentially sensitive backend responses, stack traces, and unhandled authentication errors are not printed to the browser console, thus preventing the leakage of information to background extensions or users.

---
*PR created automatically by Jules for task [15405819182974928497](https://jules.google.com/task/15405819182974928497) started by @RockHarr*