### PR TITLE
🛡️ Sentinel: Add security headers to vercel.json

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The application was directly rendering `expense.evidenciaUrl` in an `href` attribute without sanitization in the `AdminDashboard`. This allowed for potential Cross-Site Scripting (XSS) if an attacker could input a malicious payload (e.g., `javascript:alert(1)`) into the URL.
 **Learning:** Any user-supplied data used in attributes like `href`, `src`, or `action` must be treated as untrusted and sanitized before rendering, even if it comes from a supposedly secure backend or database, to follow the principle of defense-in-depth.
 **Prevention:** Use a dedicated sanitization function like `getSafeUrl` to validate the URL's protocol against an allowlist (e.g., `http:`, `https:`, `mailto:`, `tel:`) before rendering it in the UI.
+
+## 2026-06-27 - [Missing Security Headers and E2E Environment Constraints]
+**Vulnerability:** The application was missing critical security headers in `vercel.json` (such as CSP, X-Frame-Options, X-Content-Type-Options), increasing risk for XSS and Clickjacking.
+**Learning:** When configuring Content Security Policy (CSP) for this specific application deployed on Vercel, local CI/E2E tests require dummy backend URLs (like `127.0.0.1:54321` and `localhost`) to be explicitly whitelisted in the `connect-src` directive. Otherwise, tests run against the production build fail due to blocked local fetches.
+**Prevention:** Always test CSP changes against the CI build process and ensure both production external dependencies (CDNs, Supabase) and CI backend emulators are included in the policy.

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,33 @@
             "destination": "/index.html"
         }
     ],
+    "headers": [
+        {
+            "source": "/(.*)",
+            "headers": [
+                {
+                    "key": "Content-Security-Policy",
+                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://aistudiocdn.com https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://aistudiocdn.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co http://127.0.0.1:54321 http://localhost:3000 ws://localhost:3000; img-src 'self' data: blob:;"
+                },
+                {
+                    "key": "X-Content-Type-Options",
+                    "value": "nosniff"
+                },
+                {
+                    "key": "X-Frame-Options",
+                    "value": "DENY"
+                },
+                {
+                    "key": "X-XSS-Protection",
+                    "value": "1; mode=block"
+                },
+                {
+                    "key": "Referrer-Policy",
+                    "value": "strict-origin-when-cross-origin"
+                }
+            ]
+        }
+    ],
     "buildCommand": "npm run build",
     "outputDirectory": "dist",
     "cleanUrls": true


### PR DESCRIPTION
🚨 Severity: HIGH/MEDIUM
💡 Vulnerability: The application lacked standard security headers (CSP, X-Frame-Options, X-Content-Type-Options) in its deployment configuration, leaving it exposed to XSS, MIME-sniffing, and clickjacking attacks.
🎯 Impact: Attackers could potentially execute arbitrary scripts, embed the application in malicious frames (clickjacking), or exploit MIME-sniffing vulnerabilities.
🔧 Fix: Added a robust set of security headers to `vercel.json` (including `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy`) while strictly whitelisting required CDNs, Supabase, and local CI testing ports. Also updated the Sentinel journal with these configuration learnings.
✅ Verification: Ran `pnpm build` and `npx playwright test` (E2E tests pass by connecting via whitelisted localhost/127.0.0.1 origins). Checked `vercel.json` contents to confirm correct JSON formatting.

---
*PR created automatically by Jules for task [12670723760710049423](https://jules.google.com/task/12670723760710049423) started by @RockHarr*