### PR TITLE
🎨 Palette: Fix keyboard accessibility for hover-hidden actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2024-05-18 - Ensure Keyboard Accessibility for Hover-Hidden UI Actions
+**Learning:** In Tailwind CSS, when using `opacity-0 group-hover:opacity-100` to hide secondary action buttons until hovered, these interactive elements remain invisible to users navigating via keyboard (tabbing).
+**Action:** Always pair `group-hover:opacity-100` with `group-focus-within:opacity-100` (or `focus-within:opacity-100` on the container) to ensure the actions become visible when focused, maintaining WCAG keyboard accessibility standards.

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -773,7 +773,7 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
                         </div>
                       </div>
 
-                      <div className="flex justify-end gap-3 pt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                      <div className="flex justify-end gap-3 pt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100 transition-opacity">
                         <Button
                           onClick={() => setRejectModalOpen(expense)}
                           variant="danger"

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,10 +149,11 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    aria-label="Gestionar Tipos de Reserva"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
@@ -160,12 +161,14 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                   <button
                     onClick={() => handleOpenModal(amenity)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    aria-label="Editar espacio"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
                     className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    aria-label="Eliminar espacio"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,18 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  aria-label="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
                   className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  aria-label="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>


### PR DESCRIPTION
💡 What: Made secondary action buttons (like edit and delete) visible when focused via keyboard navigation, and added descriptive ARIA labels to them.
🎯 Why: Previously, these buttons were only visible on mouse hover (`group-hover:opacity-100`), making them completely invisible and inaccessible to users navigating the site using a keyboard. The lack of ARIA labels also made them indistinguishable for screen reader users.
♿ Accessibility: Improved WCAG compliance by ensuring interactive elements are visible when focused and have meaningful text alternatives.

---
*PR created automatically by Jules for task [6411544503048025983](https://jules.google.com/task/6411544503048025983) started by @RockHarr*