### PR TITLE
🛡️ Sentinel: Add security headers and CSP to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,32 @@
     ],
     "buildCommand": "npm run build",
     "outputDirectory": "dist",
-    "cleanUrls": true
+    "cleanUrls": true,
+    "headers": [
+        {
+            "source": "/(.*)",
+            "headers": [
+                {
+                    "key": "Content-Security-Policy",
+                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://aistudiocdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co http://127.0.0.1:54321; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'none';"
+                },
+                {
+                    "key": "X-Content-Type-Options",
+                    "value": "nosniff"
+                },
+                {
+                    "key": "X-Frame-Options",
+                    "value": "DENY"
+                },
+                {
+                    "key": "X-XSS-Protection",
+                    "value": "1; mode=block"
+                },
+                {
+                    "key": "Referrer-Policy",
+                    "value": "strict-origin-when-cross-origin"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Adds security headers and Content-Security-Policy (CSP) to `vercel.json` to enhance the security posture of the application.

- Added `Content-Security-Policy` with explicitly allowed domains for scripts, styles, images, and connections (including Supabase).
- Added `X-Content-Type-Options: nosniff`.
- Added `X-Frame-Options: DENY`.
- Added `X-XSS-Protection: 1; mode=block`.
- Added `Referrer-Policy: strict-origin-when-cross-origin`.

---
*PR created automatically by Jules for task [1822611557395353801](https://jules.google.com/task/1822611557395353801) started by @RockHarr*