### PR TITLE
🎨 Palette: Add ARIA label to remove image button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-05-24 - Dynamic Content Removal Accessibility
+**Learning:** Dynamic file/image removal buttons (like the one in CreateTicketScreen) are often missed during initial accessibility audits because they only appear after user interaction.
+**Action:** Always verify keyboard accessibility and ARIA labels for UI elements that conditionally render based on user input, especially for destructive actions like removing an uploaded file.

--- a/components/TicketsScreen.tsx
+++ b/components/TicketsScreen.tsx
@@ -288,6 +288,7 @@ export const CreateTicketScreen: React.FC<CreateTicketScreenProps> = ({ onAddTic
                             setError(null);
                           }}
                           className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 shadow-md hover:bg-red-600"
+                          aria-label="Quitar imagen"
                         >
                           <Icons name="xmark" className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
Added `aria-label="Quitar imagen"` to the remove image icon-only button (`<Icons name="xmark" />`) in `CreateTicketScreen` (`components/TicketsScreen.tsx`) to improve accessibility for screen readers. Also added a journal entry to `.Jules/palette.md` noting the importance of verifying keyboard accessibility and ARIA labels for UI elements that conditionally render based on user input, especially for destructive actions.

---
*PR created automatically by Jules for task [8568544025003396857](https://jules.google.com/task/8568544025003396857) started by @RockHarr*