### PR TITLE
🎨 Palette: Accessible hover-revealed action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2024-05-24 - Accessible Hover Actions
+**Learning:** When using hover-revealed actions (like Tailwind's `group-hover:opacity-100`), they become inaccessible to keyboard users because focus events do not trigger hover states.
+**Action:** Always pair `group-hover:opacity-100` with `group-focus-within:opacity-100` on the container, and add `focus-visible:ring-2` (and `focus-visible:outline-none`) to the interactive elements inside to ensure they remain accessible to keyboard navigation. Also ensure icon-only buttons have descriptive `aria-label`s.

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -773,7 +773,7 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
                         </div>
                       </div>
 
-                      <div className="flex justify-end gap-3 pt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                      <div className="flex justify-end gap-3 pt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
                         <Button
                           onClick={() => setRejectModalOpen(expense)}
                           variant="danger"

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,26 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     title="Gestionar Tipos de Reserva"
+                    aria-label="Gestionar tipos de reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label="Editar espacio"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                    aria-label="Eliminar espacio"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,18 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                  aria-label="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>

--- a/tests/e2e/setup.spec.ts
+++ b/tests/e2e/setup.spec.ts
@@ -8,6 +8,9 @@ test.describe('System Setup', () => {
         // 1. Login as Admin
         await page.goto('/');
 
+        // Wait for the login screen to render
+        await expect(page.getByRole('heading', { name: 'Bienvenido' })).toBeVisible();
+
         const emailInput = page.locator('input[type="email"]');
         await expect(emailInput).toBeVisible();
         await emailInput.fill(ADMIN_EMAIL);

--- a/tests/e2e/setup.spec.ts
+++ b/tests/e2e/setup.spec.ts
@@ -43,7 +43,7 @@ test.describe('System Setup', () => {
         const card = page.locator('.group', { has: page.getByRole('heading', { name: 'Quincho', exact: true }) }).first();
         // Force click the hidden button or hover
         await card.hover();
-        const manageTypesBtn = card.getByTitle('Gestionar Tipos de Reserva');
+        const manageTypesBtn = card.getByRole('button', { name: 'Gestionar tipos de reserva' });
         await manageTypesBtn.click();
 
         await expect(page.getByRole('heading', { name: 'Tipos de Reserva' })).toBeVisible();


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility and screen reader support to hover-revealed action buttons across administrative lists.

🎯 **Why:** Previously, action buttons (like edit/delete) inside lists used Tailwind's `group-hover:opacity-100` to remain hidden until hovered. This pattern makes the actions completely inaccessible to keyboard users and screen readers, as focus events do not trigger hover states. 

♿ **Accessibility:** 
- Paired `group-hover:opacity-100` with `group-focus-within:opacity-100` on the container so actions reveal when tabbing into the row.
- Added `focus-visible:ring-2` to the buttons to clearly indicate which button has focus.
- Added translated `aria-label`s to all icon-only buttons (e.g., "Editar espacio", "Eliminar tipo de reserva").

---
*PR created automatically by Jules for task [9323628696213253998](https://jules.google.com/task/9323628696213253998) started by @RockHarr*