### PR TITLE
🎨 Palette: Fix keyboard accessibility for hover-revealed actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2025-05-25 - Hover-revealed actions and keyboard accessibility
+**Learning:** Hover-revealed actions using `group-hover:opacity-100` hide interactive elements from keyboard users.
+**Action:** Always pair `group-hover:opacity-100` with `group-focus-within:opacity-100` on the container, and ensure interactive elements have `focus-visible:ring-2` to remain accessible to keyboard navigation.

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -773,7 +773,7 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
                         </div>
                       </div>
 
-                      <div className="flex justify-end gap-3 pt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                      <div className="flex justify-end gap-3 pt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
                         <Button
                           onClick={() => setRejectModalOpen(expense)}
                           variant="danger"

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,23 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none" aria-label="Editar espacio"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none" aria-label="Eliminar espacio"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus:outline-none" aria-label="Editar tipo"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none" aria-label="Eliminar tipo"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>


### PR DESCRIPTION
💡 What: The UX enhancement added
Added keyboard accessibility to hover-revealed action buttons across the application. Modified `AmenitiesManager`, `ReservationTypesManager`, and `AdminDashboard` to ensure action buttons appear when they or their containers receive keyboard focus, and added explicit `aria-label`s to icon-only buttons.

🎯 Why: The user problem it solves
Previously, several action buttons (edit, delete) in list views were revealed only on mouse hover (`group-hover:opacity-100`), making them completely invisible to keyboard-only users and difficult for screen reader users to discover. This change ensures feature parity for keyboard navigation and screen readers.

♿ Accessibility:
- Added `group-focus-within:opacity-100` to containers so actions appear on tab focus.
- Added `focus-visible:ring-2` to buttons for clear focus indication.
- Added explicit `aria-label` attributes to icon-only buttons ("Editar espacio", "Eliminar tipo", etc.).


---
*PR created automatically by Jules for task [14300788350302310265](https://jules.google.com/task/14300788350302310265) started by @RockHarr*