### PR TITLE
🎨 Palette: Mejorar accesibilidad por teclado en botones de acción

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2025-05-24 - Accessibility on hover-revealed action buttons
+**Learning:** Icon-only action buttons (like Edit/Delete) that are revealed via `group-hover` are completely inaccessible to keyboard users because they cannot hover, nor can they tab to hidden elements if they aren't part of a focusable group logic.
+**Action:** When using `group-hover:opacity-100` on a container, always pair it with `group-focus-within:opacity-100` so tabbing into the container reveals the buttons. Also, always add explicit `focus-visible:ring-2 focus-visible:outline-none` and `aria-label` attributes to the buttons.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -111,7 +111,7 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
           <div className="flex items-center gap-2 mb-1">
             <button
               onClick={() => onNavigate('admin-dashboard')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus-visible:ring-2 focus-visible:outline-none rounded-full p-1" aria-label="Volver al panel"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -149,23 +149,23 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2 focus-visible:outline-none" aria-label="Gestionar Tipos de Reserva"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2 focus-visible:outline-none" aria-label="Editar espacio común"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2 focus-visible:outline-none" aria-label="Eliminar espacio común"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -148,7 +148,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
           <div className="flex items-center gap-2 mb-1">
             <button
               onClick={() => onNavigate('admin-amenities')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus-visible:ring-2 focus-visible:outline-none rounded-full p-1" aria-label="Volver a espacios comunes"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -176,16 +176,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:ring-2 focus-visible:outline-none" aria-label="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:ring-2 focus-visible:outline-none" aria-label="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>


### PR DESCRIPTION
Added `group-focus-within:opacity-100`, `focus-visible:ring-2`, and explicit `aria-label`s to hover-revealed icon-only buttons in `AmenitiesManager` and `ReservationTypesManager` components. This allows keyboard navigation to reveal and interact with the Edit/Delete actions properly.

---
*PR created automatically by Jules for task [5940056134868351994](https://jules.google.com/task/5940056134868351994) started by @RockHarr*