### PR TITLE
🎨 Palette: Improve keyboard accessibility for hover-revealed action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2024-07-22 - Keyboard navigation for hover-revealed action buttons
+**Learning:** Action buttons that are only revealed on `group-hover` become completely invisible to keyboard-only users navigating via tab stops, failing accessibility standards.
+**Action:** When implementing hover-revealed actions using Tailwind's `group-hover:opacity-100`, always pair it with `group-focus-within:opacity-100` on the container, and add `focus-visible:ring-2` styling alongside translated `aria-label` attributes to the internal buttons to ensure they are discoverable and usable by keyboard navigation and screen readers.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,26 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
                     title="Gestionar Tipos de Reserva"
+                    aria-label="Gestionar tipos de reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label="Editar espacio común"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                    aria-label="Eliminar espacio común"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,18 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                  aria-label="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>


### PR DESCRIPTION
I noticed that the edit and delete action buttons in `ReservationTypesManager` and `AmenitiesManager` were only revealed on hover (`group-hover:opacity-100`). This made them completely inaccessible to users navigating via keyboard.

**What I changed:**
* Added `group-focus-within:opacity-100` to the action containers so they become visible when a child element receives focus.
* Added `focus:outline-none focus-visible:ring-2` to the buttons themselves to provide a clear visual indicator of focus.
* Added descriptive `aria-label` attributes (e.g., "Editar espacio común", "Eliminar tipo de reserva") to the icon-only buttons for screen reader support.

This is a micro-UX improvement that directly addresses an accessibility barrier without altering the visual design for mouse users.

---
*PR created automatically by Jules for task [8212261034889875317](https://jules.google.com/task/8212261034889875317) started by @RockHarr*