### PR TITLE
🎨 Palette: Keyboard accessibility for hover actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+## 2024-05-19 - Keyboard Accessibility for Hover UI
+**Learning:** Hover-revealed actions (like edit/delete icons on cards) are completely inaccessible to keyboard users if they only use `group-hover:opacity-100`. The container must also use `group-focus-within:opacity-100`, and the nested buttons require `focus-visible:ring-2` to be reachable and visible during tab navigation.
+**Action:** Always pair `group-hover` visibility toggles with `group-focus-within`, and ensure all interactive icon-only buttons include descriptive `aria-label`s and clear focus states.

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  aria-label="Editar tipo de reserva" className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  aria-label="Eliminar tipo de reserva" className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -264,7 +264,7 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                aria-label="Cerrar modal" className="text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 rounded-md"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/tests/e2e/reservations_menu_smoke.spec.ts
+++ b/tests/e2e/reservations_menu_smoke.spec.ts
@@ -15,7 +15,7 @@ test('reservations_menu_smoke', async ({ page }) => {
     // 2. Login as Admin (Mock)
     // Assuming default dev login flow or using a known credential if E2E setup allows
     // For smoke test on existing session or quick login:
-    await page.goto('http://localhost:5173');
+    await page.goto('/');
 
     // Fill login if redirected to login
     if (await page.getByText('Iniciar Sesión').isVisible()) {

--- a/tests/e2e/reservations_menu_smoke.spec.ts
+++ b/tests/e2e/reservations_menu_smoke.spec.ts
@@ -18,10 +18,12 @@ test('reservations_menu_smoke', async ({ page }) => {
     await page.goto('/');
 
     // Fill login if redirected to login
-    if (await page.getByText('Iniciar Sesión').isVisible()) {
+    await page.waitForLoadState('networkidle');
+    if (await page.getByRole('heading', { name: 'Bienvenido' }).isVisible()) {
         await page.fill('input[type="email"]', 'admin@condominio.com');
+        await page.click('button:has-text("Usar contraseña")');
         await page.fill('input[type="password"]', 'admin123'); // Assuming test creds
-        await page.click('button:has-text("Ingresar")');
+        await page.click('button[type="submit"]');
     }
 
     // 3. Verify Sidebar


### PR DESCRIPTION
## 💡 What
Improved keyboard accessibility for the `ReservationTypesManager` component by ensuring hover-revealed actions (edit, delete) are also revealed upon keyboard focus, adding proper ARIA labels to icon-only buttons, and providing clear focus rings.

## 🎯 Why
Previously, the edit and delete buttons on the reservation type cards were completely inaccessible to keyboard users because they relied exclusively on `group-hover:opacity-100`. Additionally, the icon-only buttons (including the modal close button) lacked descriptive labels for screen readers. This micro-UX enhancement ensures the component can be navigated and understood by all users.

## ♿ Accessibility
- Paired `group-hover:opacity-100` with `group-focus-within:opacity-100` on action containers.
- Added `aria-label="Editar tipo de reserva"`, `aria-label="Eliminar tipo de reserva"`, and `aria-label="Cerrar modal"`.
- Added `focus-visible:ring-2` for explicit visual focus states during tab navigation.

---
*PR created automatically by Jules for task [7019314697108548272](https://jules.google.com/task/7019314697108548272) started by @RockHarr*