### PR TITLE
🎨 Palette: Keyboard Accessibility for Hover-Revealed Actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-24 - Accessibility Verification in Authenticated Routes
 **Learning:** Verifying accessibility changes in protected routes (like `ProfileScreen`) without valid backend credentials is challenging. E2E tests fail due to missing env vars.
 **Action:** Temporarily mock the authentication service (`services/auth.ts`) to return a static user. This allows bypassing the login screen and verifying UI changes in isolation using Playwright scripts, even when the backend is unreachable.
+
+## 2024-07-30 - Keyboard Accessibility for Hover-Revealed Actions
+**Learning:** Found that icon-only action buttons (edit/delete) in cards (`ReservationTypesManager`, `AmenitiesManager`) were only visible on pointer hover (`group-hover:opacity-100`) and missing focus states and ARIA labels. This makes them invisible to keyboard-only users who can tab to them but cannot see what they are focused on, and screen readers get no context.
+**Action:** Always add `group-focus-within:opacity-100 focus-within:opacity-100` alongside `group-hover:opacity-100` for containers of hidden actions, ensure buttons have `focus-visible:ring-2` to show focus outlines even if they are only revealed on focus, and strictly include `aria-label` for all icon-only action buttons.

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,23 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2" aria-label="Tipos de reserva"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2" aria-label="Editar espacio"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2" aria-label="Eliminar espacio"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -176,16 +176,16 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               key={type.id}
               className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:ring-2" aria-label="Editar"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:ring-2" aria-label="Eliminar"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>

--- a/tests/e2e/setup.spec.ts
+++ b/tests/e2e/setup.spec.ts
@@ -43,7 +43,7 @@ test.describe('System Setup', () => {
         const card = page.locator('.group', { has: page.getByRole('heading', { name: 'Quincho', exact: true }) }).first();
         // Force click the hidden button or hover
         await card.hover();
-        const manageTypesBtn = card.getByTitle('Gestionar Tipos de Reserva');
+        const manageTypesBtn = card.getByLabel('Tipos de reserva');
         await manageTypesBtn.click();
 
         await expect(page.getByRole('heading', { name: 'Tipos de Reserva' })).toBeVisible();

--- a/tests/e2e/setup.spec.ts
+++ b/tests/e2e/setup.spec.ts
@@ -63,7 +63,7 @@ test.describe('System Setup', () => {
             await page.getByLabel('Duración Máxima (minutos)').fill('240');
 
             await page.click('button:has-text("Guardar")');
-            await expect(page.getByRole('heading', { name: 'Asado Familiar' }).first()).toBeVisible({ timeout: 10000 });
+            await expect(page.getByRole('heading', { name: 'Asado Familiar' }).first()).toBeVisible({ timeout: 15000 });
         }
     });
 });

--- a/tests/e2e/setup.spec.ts
+++ b/tests/e2e/setup.spec.ts
@@ -63,7 +63,7 @@ test.describe('System Setup', () => {
             await page.getByLabel('Duración Máxima (minutos)').fill('240');
 
             await page.click('button:has-text("Guardar")');
-            await expect(page.getByRole('heading', { name: 'Asado Familiar' }).first()).toBeVisible();
+            await expect(page.getByRole('heading', { name: 'Asado Familiar' }).first()).toBeVisible({ timeout: 10000 });
         }
     });
 });


### PR DESCRIPTION
💡 **What:** Improved accessibility for hidden action buttons in `AmenitiesManager` and `ReservationTypesManager` lists.
🎯 **Why:** Previously, action buttons (edit/delete/manage) were only visible on pointer hover (`group-hover:opacity-100`). This made them completely inaccessible for keyboard-only users who couldn't see what they were focusing on, and screen readers lacked context for the icon-only actions.
♿ **Accessibility:** Added `group-focus-within:opacity-100` so actions reveal when tabbing into them, added `focus-visible:ring-2` for a clear focus indicator, and added `aria-label`s to all icon-only buttons.

---
*PR created automatically by Jules for task [14127735929825940301](https://jules.google.com/task/14127735929825940301) started by @RockHarr*