### PR TITLE
🎨 Palette: Fix keyboard accessibility and missing ARIA labels for icon buttons in Amenity Managers

### DIFF
--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -149,23 +149,26 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                     <Icons name="photo" className="w-12 h-12" />
                   </div>
                 )}
-                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2 focus-visible:ring-green-500"
+                    aria-label="Gestionar tipos de reserva"
                     title="Gestionar Tipos de Reserva"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label="Editar amenidad"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2 focus-visible:ring-red-500"
+                    aria-label="Eliminar amenidad"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -211,7 +214,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 rounded focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -148,7 +148,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
           <div className="flex items-center gap-2 mb-1">
             <button
               onClick={() => onNavigate('admin-amenities')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded focus-visible:ring-2 focus-visible:ring-blue-500"
+              aria-label="Volver a amenidades"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -174,18 +175,20 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
           {types.map((type) => (
             <Card
               key={type.id}
-              className="group hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
+              className="group focus-within:ring-2 focus-within:ring-blue-500 hover:shadow-lg transition-all duration-200 border border-gray-100 dark:border-gray-700 relative"
             >
-              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-500"
+                  aria-label="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -264,7 +267,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 rounded focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
### 💡 What
This PR adds essential accessibility and micro-UX improvements to the action buttons inside the `AmenitiesManager` and `ReservationTypesManager` components. Specifically:
- **Screen Reader Support:** Added clear, descriptive `aria-label`s to all icon-only buttons (e.g., "Editar tipo de reserva", "Cerrar modal").
- **Keyboard Navigation:** Added `focus-visible:ring-2` focus indicators so users navigating via keyboard can easily track their position.
- **Focus Revealing:** Buttons that were previously hidden and only revealed on mouse hover (`group-hover:opacity-100`) are now also revealed when focused via keyboard navigation (`group-focus-within:opacity-100`).

### 🎯 Why
These changes ensure that critical admin management features (editing and deleting amenities and reservation types) are accessible to screen reader users and those navigating exclusively via keyboard. Previously, these actions were difficult to discover and interact with for keyboard users because the buttons remained invisible (opacity 0) unless a mouse hovered over the card.

### ♿ Accessibility
- Improved keyboard operability and visible focus states.
- Ensured icon-only controls announce their purpose to assistive technologies.

---
*PR created automatically by Jules for task [16509638526420957819](https://jules.google.com/task/16509638526420957819) started by @RockHarr*