### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/components/AdminCreateReservationModal.tsx
+++ b/components/AdminCreateReservationModal.tsx
@@ -78,7 +78,7 @@ export const AdminCreateReservationModal: React.FC<AdminCreateReservationModalPr
                     <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                         Nueva Reserva (Admin)
                     </h2>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/AmenitiesManager.tsx
+++ b/components/AmenitiesManager.tsx
@@ -111,7 +111,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
           <div className="flex items-center gap-2 mb-1">
             <button
               onClick={() => onNavigate('admin-dashboard')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+              aria-label="Volver al panel de administración"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -152,20 +153,23 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
                 <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
                     onClick={() => onNavigate('admin-reservation-types', { amenityId: amenity.id })}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-green-50 text-green-600 focus-visible:ring-2 focus-visible:ring-green-500"
                     title="Gestionar Tipos de Reserva"
+                    aria-label="Gestionar tipos de reserva para este espacio"
                   >
                     <Icons name="clipboard-document-list" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleOpenModal(amenity)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-blue-50 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500"
+                    aria-label="Editar espacio común"
                   >
                     <Icons name="pencil" className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(amenity.id)}
-                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600"
+                    className="p-2 bg-white/90 dark:bg-gray-800/90 rounded-full shadow-sm hover:bg-red-50 text-red-600 focus-visible:ring-2 focus-visible:ring-red-500"
+                    aria-label="Eliminar espacio común"
                   >
                     <Icons name="trash" className="w-4 h-4" />
                   </button>
@@ -211,7 +215,8 @@ export const AmenitiesManager: React.FC<AmenitiesManagerProps> = ({ onNavigate }
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>

--- a/components/ExpenseStatementModal.tsx
+++ b/components/ExpenseStatementModal.tsx
@@ -81,7 +81,7 @@ export const ExpenseStatementModal: React.FC<ExpenseStatementModalProps> = ({
                         Estado de Gasto Común
                     </h2>
                     <div className="flex gap-3">
-                        <button onClick={onClose} className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors">
+                        <button onClick={onClose} className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg transition-colors" aria-label="Cerrar modal">
                             Cerrar
                         </button>
                         <button onClick={handlePrint} className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-sm flex items-center gap-2 transition-colors">

--- a/components/ReservationRequestModal.tsx
+++ b/components/ReservationRequestModal.tsx
@@ -145,7 +145,7 @@ export const ReservationRequestModal: React.FC<ReservationRequestModalProps> = (
                             {amenity.name} - {selectedDate.toLocaleDateString()}
                         </p>
                     </div>
-                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md" aria-label="Cerrar modal">
                         <Icons name="xmark" className="w-6 h-6" />
                     </button>
                 </div>

--- a/components/ReservationTypesManager.tsx
+++ b/components/ReservationTypesManager.tsx
@@ -148,7 +148,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
           <div className="flex items-center gap-2 mb-1">
             <button
               onClick={() => onNavigate('admin-amenities')}
-              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+              aria-label="Volver a espacios comunes"
             >
               <Icons name="arrow-left" className="w-5 h-5" />
             </button>
@@ -179,13 +180,15 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                 <button
                   onClick={() => handleOpenModal(type)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-blue-600 hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label="Editar tipo de reserva"
                 >
                   <Icons name="pencil" className="w-4 h-4" />
                 </button>
                 <button
                   onClick={() => handleDelete(type.id)}
-                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50"
+                  className="p-1.5 bg-gray-100 dark:bg-gray-700 rounded-lg text-red-600 hover:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-500"
+                  aria-label="Eliminar tipo de reserva"
                 >
                   <Icons name="trash" className="w-4 h-4" />
                 </button>
@@ -264,7 +267,8 @@ export const ReservationTypesManager: React.FC<ReservationTypesManagerProps> = (
               </h2>
               <button
                 onClick={() => setModalOpen(false)}
-                className="text-gray-400 hover:text-gray-500"
+                className="text-gray-400 hover:text-gray-500 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+                aria-label="Cerrar modal"
               >
                 <Icons name="xmark" className="w-6 h-6" />
               </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes and standard Tailwind `focus-visible:ring-2` focus rings to multiple icon-only buttons (like close "x", trash, and pencil icons) across the admin components.

🎯 Why: These small buttons lacked context for screen reader users and did not have distinct keyboard focus indicators, degrading the accessibility and general keyboard navigability of these modal and management views.

♿ Accessibility:
* Screen readers will now correctly announce the action (e.g., "Cerrar modal", "Eliminar tipo de reserva") instead of just "button".
* Keyboard users will see a clear blue or red ring when tabbing onto these actions, meeting WCAG focus visibility standards.

---
*PR created automatically by Jules for task [17744689920924940942](https://jules.google.com/task/17744689920924940942) started by @RockHarr*