### PR TITLE
🛡️ Sentinel: Add security headers to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,36 @@
     ],
     "buildCommand": "npm run build",
     "outputDirectory": "dist",
-    "cleanUrls": true
+    "cleanUrls": true,
+    "headers": [
+        {
+            "source": "/(.*)",
+            "headers": [
+                {
+                    "key": "Content-Security-Policy",
+                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; font-src 'self' data:; frame-ancestors 'none';"
+                },
+                {
+                    "key": "X-Content-Type-Options",
+                    "value": "nosniff"
+                },
+                {
+                    "key": "X-Frame-Options",
+                    "value": "DENY"
+                },
+                {
+                    "key": "X-XSS-Protection",
+                    "value": "1; mode=block"
+                },
+                {
+                    "key": "Referrer-Policy",
+                    "value": "strict-origin-when-cross-origin"
+                },
+                {
+                    "key": "Strict-Transport-Security",
+                    "value": "max-age=31536000; includeSubDomains; preload"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
🛡️ **Sentinel: Add security headers to vercel.json**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was missing standard security headers (Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, etc.), leaving it exposed to clickjacking, MIME-type sniffing, and increasing the risk of cross-site scripting (XSS) attacks.
🎯 **Impact:** Without these headers, browsers lack instructions on how to handle content safely, potentially allowing attackers to embed the site in malicious frames or execute unauthorized scripts.
🔧 **Fix:** Added a comprehensive set of security headers to `vercel.json`, including a Content Security Policy (CSP) tailored for the application, HSTS, and X-Frame-Options.
✅ **Verification:** Verified locally that `vercel.json` is correctly structured and builds successfully.

---
*PR created automatically by Jules for task [3832885946487715950](https://jules.google.com/task/3832885946487715950) started by @RockHarr*